### PR TITLE
WritePaper, MessagePage 수정

### DIFF
--- a/src/components/TextEditor/TextEditor.jsx
+++ b/src/components/TextEditor/TextEditor.jsx
@@ -1,5 +1,6 @@
 import ReactQuill from 'react-quill-new';
 import 'react-quill-new/dist/quill.snow.css';
+import styles from './TextEditor.module.css';
 
 function TextEditor({ value, onChange, selectedFont }) {
 	const modules = {
@@ -14,7 +15,7 @@ function TextEditor({ value, onChange, selectedFont }) {
 	const formats = ['bold', 'italic', 'underline', 'align', 'list', 'color'];
 
 	return (
-		<div>
+		<div className={styles.editor}>
 			<ReactQuill
 				value={value}
 				onChange={onChange}

--- a/src/components/TextEditor/TextEditor.module.css
+++ b/src/components/TextEditor/TextEditor.module.css
@@ -1,0 +1,11 @@
+.editor :global(.ql-editor) {
+	width: 320px;
+	height: 220px;
+}
+
+/* Tablet */
+@media (min-width: 768px) {
+	.editor :global(.ql-editor) {
+		width: 720px;
+	}
+}

--- a/src/components/TextField/TextDropdown.jsx
+++ b/src/components/TextField/TextDropdown.jsx
@@ -39,7 +39,11 @@ function TextDropdown({ value, options, onChange }) {
 			{isOpen && (
 				<ul className={styles.dropdownList}>
 					{options.map((option, index) => (
-						<li key={index} onClick={() => handleSelect(option)}>
+						<li
+							key={index}
+							onClick={() => handleSelect(option)}
+							style={{ fontFamily: `${option}, sans-serif` }}
+						>
 							<p className={styles.dropdownOption}>{option}</p>
 						</li>
 					))}

--- a/src/components/TextField/TextInput.jsx
+++ b/src/components/TextField/TextInput.jsx
@@ -2,7 +2,7 @@ import styles from './TextInput.module.css';
 
 function TextInput({ type, value, placeholder, onChange, error, errorMessage, onBlur, maxLength }) {
 	return (
-		<div>
+		<div className={styles.wrapper}>
 			<input
 				className={`${styles.container} ${error && styles.error}`}
 				type={type}
@@ -10,9 +10,11 @@ function TextInput({ type, value, placeholder, onChange, error, errorMessage, on
 				placeholder={placeholder}
 				onChange={onChange}
 				onBlur={onBlur}
-				maxLength={40}
+				maxLength={maxLength}
 			/>
-			{error && <div className={styles.errorMessage}>{errorMessage}</div>}
+			<div className={styles.feedback}>
+				{error && <div className={styles.errorMessage}>{errorMessage}</div>}
+			</div>
 		</div>
 	);
 }

--- a/src/components/TextField/TextInput.module.css
+++ b/src/components/TextField/TextInput.module.css
@@ -1,4 +1,5 @@
 .container {
+	position: relative;
 	width: 320px;
 	height: 50px;
 	border: 1px solid var(--gray-300);
@@ -6,6 +7,14 @@
 	padding: 12px 55px 12px 16px;
 	font-size: var(--font-16);
 	font-weight: var(--font-regular);
+}
+
+.wrapper {
+	position: relative;
+}
+
+.feedback {
+	position: absolute;
 }
 
 .container:focus {
@@ -30,6 +39,16 @@
 	font-weight: var(--font-regular);
 	line-height: 18px;
 	letter-spacing: -0.5%;
+}
+
+.charCount {
+	position: absolute;
+	top: 58%;
+	transform: translateY(-50%);
+	right: 10px;
+	font-size: 12px;
+	color: var(--gray-400);
+	pointer-events: none;
 }
 
 /* Tablet */

--- a/src/components/buttons/Button/Button.module.css
+++ b/src/components/buttons/Button/Button.module.css
@@ -17,7 +17,7 @@
 	background-color: var(--purple-600);
 	width: 320px;
 	height: 56px;
-	border-radius: 2px;
+	border-radius: 12px;
 	bottom: 24px;
 	color: var(--white);
 	font-size: var(--font-18);
@@ -32,6 +32,7 @@
 	background-color: var(--gray-300);
 	font-weight: var(--font-bold);
 	cursor: not-allowed;
+	border-radius: 12px;
 }
 
 .disabled:hover {
@@ -50,6 +51,20 @@
 	font-weight: var(--font-bold);
 	font-size: 12px;
 	padding: 4px 8px;
+}
+
+.large {
+	position: sticky;
+	border: none;
+	outline: none;
+	background-color: var(--purple-600);
+	width: 720px;
+	height: 56px;
+	border-radius: 12px;
+	bottom: 24px;
+	color: var(--white);
+	font-size: var(--font-18);
+	font-weight: var(--font-bold);
 }
 
 /* Tablet */

--- a/src/pages/MessagePage/MessagePage.jsx
+++ b/src/pages/MessagePage/MessagePage.jsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet';
 import { useState, useEffect } from 'react';
 import styles from './MessagesPage.module.css';
 import Header from '../../components/headers/Header/Header';
@@ -11,6 +12,7 @@ import { TEAM } from '../../constants/endPoints';
 import { recipientsAPI } from '../../api/index.js';
 import { useNavigate, useParams } from 'react-router-dom';
 import TextEditor from '../../components/TextEditor/TextEditor.jsx';
+import { useScreenSize } from '../../hooks/useScreenSize';
 
 function MessagePage() {
 	const [sender, setSender] = useState('');
@@ -32,6 +34,9 @@ function MessagePage() {
 
 	const [content, setContent] = useState('');
 
+	const screenSize = useScreenSize();
+	const buttonSize = screenSize === 'sm' ? 'primary' : 'large';
+
 	console.log(id);
 
 	useEffect(() => {
@@ -50,7 +55,7 @@ function MessagePage() {
 		};
 
 		fetchData();
-	}, [fetchProfiles]);
+	}, []);
 
 	//로딩 작동하는지 다시 확인해봐야함.
 	if (isLoading) {
@@ -80,7 +85,7 @@ function MessagePage() {
 				font: selectedFont,
 			};
 			await postMessage(recipientId, data);
-			console.log('메세지가 전송되었습니다!', data); // 토스트로 변경할 수도 있음.
+			console.log('메세지가 전송되었습니다!', data);
 			navigate(`/post/${id}`, { replace: true });
 		} catch (err) {
 			console.error('메세지 전송 실패:', err);
@@ -89,11 +94,14 @@ function MessagePage() {
 
 	return (
 		<>
+			<Helmet>
+				<title>Rolling | Message</title>
+			</Helmet>
 			<Header isForm={true} />
 			<div className={styles.container}>
 				<form onSubmit={handleSubmit} className={styles.form}>
 					<div>
-						<h2 className={styles.h2}>From</h2>
+						<h2 className={styles.h2}>From.</h2>
 						<div className={styles.inputContainer}>
 							<TextInput
 								value={sender}
@@ -111,13 +119,14 @@ function MessagePage() {
 								}}
 								error={senderError}
 								errorMessage={'1~40자 사이 이름을 입력해주세요'}
+								maxLength={40}
 							/>
 							<span className={styles.charCount}>{sender.length} / 40</span>
 						</div>
 					</div>
-					<div>
+					<div className={styles.profilesection}>
 						<h2 className={styles.h2}>프로필 이미지</h2>
-						<p className={styles.p}>프로필 이미지를 선택해주세요!</p>
+						<p className={styles.profilep}>프로필 이미지를 선택해주세요!</p>
 						<div className={styles.wrapper}>
 							<div className={styles.profilepreview}>
 								{/* 선택된 이미지 크게 보여주기(왼쪽에 위치하도록) */}
@@ -164,13 +173,7 @@ function MessagePage() {
 						<TextDropdown options={font} value={selectedFont} onChange={setSelectedFont} />
 					</div>
 					<div className={styles.button}>
-						<Button
-							type="submit"
-							classStyle="primary"
-							extraClass="wideButton"
-							children="생성하기"
-							disabled={!sender.trim()}
-						/>
+						<Button type="submit" size={buttonSize} children="생성하기" disabled={!sender.trim()} />
 					</div>
 				</form>
 			</div>

--- a/src/pages/MessagePage/MessagesPage.module.css
+++ b/src/pages/MessagePage/MessagesPage.module.css
@@ -11,7 +11,7 @@
 	font-size: var(--font-24);
 	font-weight: var(--font-bold);
 	margin-top: 20px;
-	margin-bottom: 3px;
+	margin-bottom: 8px;
 }
 
 .p {
@@ -20,6 +20,20 @@
 	color: var(--gray-500);
 	line-height: 26px;
 	letter-spacing: -1%;
+}
+
+.profilesection {
+	position: relative;
+}
+
+.profilep {
+	position: absolute;
+	font-size: var(--font-16);
+	font-weight: var(--font-regular);
+	color: var(--gray-500);
+	line-height: 26px;
+	letter-spacing: -1%;
+	margin-left: 115px;
 }
 
 .form {
@@ -63,8 +77,10 @@
 /* 썸네일 이미지 리스트(간격 조정 필요) */
 .profilethumbnails {
 	display: grid;
-	grid-template-columns: repeat(5, 40px);
+	grid-template-columns: repeat(5, 1fr);
 	gap: 3px;
+	margin-top: 25px;
+	margin-left: 15px;
 }
 
 /* 썸네일 개별 이미지 (백그라운드이미지로 바꿀 필요있음)*/
@@ -92,4 +108,30 @@
 .button {
 	margin-top: 60px;
 	margin-bottom: 30px;
+}
+
+/* Tablet */
+@media (min-width: 768px) {
+	.profilethumbnails {
+		display: flex;
+	}
+	.thumbnail {
+		width: 56px;
+		height: 56px;
+	}
+	.profilep {
+		margin-left: 170px;
+		margin-top: 10px;
+	}
+	.profilethumbnails {
+		margin-top: 35px;
+	}
+}
+
+/* Desktop (Large) */
+@media (min-width: 1200px) {
+	.primary {
+		bottom: 40px;
+		width: 280px;
+	}
 }

--- a/src/pages/WritePaper/WritePaper.jsx
+++ b/src/pages/WritePaper/WritePaper.jsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet';
 import { useState } from 'react';
 import Header from '../../components/headers/Header/Header';
 import TextInput from '../../components/TextField/TextInput';
@@ -8,7 +9,7 @@ import useFetch from '../../hooks/useFetch';
 import { recipientsAPI } from '../../api/index.js';
 import { TEAM } from '../../constants/endPoints';
 import { useNavigate } from 'react-router';
-import classNames from 'classnames';
+import { useScreenSize } from '../../hooks/useScreenSize';
 
 function WritePaper() {
 	const [name, setName] = useState('');
@@ -17,6 +18,9 @@ function WritePaper() {
 		backgroundColor: 'beige',
 		backgroundImageURL: '',
 	});
+
+	const screenSize = useScreenSize();
+	const buttonSize = screenSize === 'sm' ? 'primary' : 'large';
 
 	const [nameError, setNameError] = useState(false);
 
@@ -66,11 +70,14 @@ function WritePaper() {
 
 	return (
 		<>
+			<Helmet>
+				<title>Rolling | Post</title>
+			</Helmet>
 			<Header isForm={true} />
 			<div className={styles.container}>
 				<form onSubmit={handleSubmit} className={styles.form}>
 					<div className={styles.inputarea}>
-						<h2 className={styles.h2}>To</h2>
+						<h2 className={styles.h2}>To.</h2>
 						<div className={styles.inputContainer}>
 							<TextInput
 								className={styles.input}
@@ -92,6 +99,7 @@ function WritePaper() {
 								placeholder="받는 사람 이름을 입력해 주세요"
 								error={nameError}
 								errorMessage="1~40자 사이 이름을 입력해주세요"
+								maxLength={40}
 							/>
 							<span className={styles.charCount}>{name.length} / 40</span>
 						</div>
@@ -108,13 +116,7 @@ function WritePaper() {
 						/>
 					</div>
 					<div className={styles.button}>
-						<Button
-							type="submit"
-							classStyle="primary"
-							extraClass="wideButton"
-							children="생성하기"
-							disabled={!name.trim()}
-						/>
+						<Button type="submit" size={buttonSize} children="생성하기" disabled={!name.trim()} />
 					</div>
 				</form>
 			</div>

--- a/src/pages/WritePaper/WritePaper.module.css
+++ b/src/pages/WritePaper/WritePaper.module.css
@@ -10,7 +10,8 @@
 .h2 {
 	font-size: var(--font-24);
 	font-weight: var(--font-bold);
-	margin-bottom: 10px;
+	margin-top: 20px;
+	margin-bottom: 8px;
 }
 
 .p {
@@ -28,7 +29,7 @@
 
 .charCount {
 	position: absolute;
-	top: 58%;
+	top: 70%;
 	transform: translateY(-50%);
 	right: 10px;
 	font-size: 12px;
@@ -37,7 +38,7 @@
 }
 
 .inputarea {
-	margin-top: 20px;
+	margin-top: 35px;
 }
 
 .input {
@@ -53,6 +54,5 @@
 }
 
 .button {
-	margin-top: 60px;
-	margin-bottom: 30px;
+	margin-top: 105px;
 }


### PR DESCRIPTION
### Helmet 추가
- Writepaper와 Messagepage에 각각 Post, Message로 헬멧 추가

### TextEditor CSS 추가
- 에디터의 가로 길이와 세로 길이 수정
- 반응형 크기 적용

### TextDropdown을 통한 폰트 프리뷰 기능 추가
- Messagepage에서 폰트 드롭다운을 선택할 경우 각각 폰트의 미리보기 제공

### TextInput 내 MaxLength 프롭스 수정
- 기존 프롭스에 오류가 있어 제대로 작동하지 않았음.
- 40자 제한으로 다시 리팩토링

### TextInput 내 글자수 카운터 CSS 변경
- 에러메시지 출력 시 글자수 카운터도 아래로 움직이는 현상이 있었음.
- 에러메시지에 absolute값을 부여하여 서로 영향을 받지 않도록 조정

### Button의 border-radius 변경 및 large 클래스 추가
- 6px로 되어있는 값을 피그마 시안에 맞게 12px로 변경
- Writepaper, Messagepage에 적용할 버튼 사이즈(large) 추가

### Messagepage 내 프로필 이미지 CSS 배열 변경
- 태블릿, PC에서는 한줄로 출력되게 변경